### PR TITLE
Added devActivity - ebmeddable widgets with cycle time and repo Stats badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ includes Shields-related and non-Shields-related resources._
 - [Badges](https://github.com/bevry/badges) &ndash; Node.js/Deno/Browser npm package for rendering the HTML of various badges
 - [Projectz](https://github.com/bevry/projectz) &ndash; Render Badges into your README based on your package.json configuration
 - [shields.io Raycast extension](https://www.raycast.com/litomore/badges) &ndash; A more convenient UI for creating shields.io badges
+- [devActivity](https://devactivity.com) &ndash; Embeddable badges: Cycle Time, Repo Stats (contributors, issues, commits, PRs etc)
 
 ### Raster badges
 


### PR DESCRIPTION
Embeddable widget aren't main features of the devActivity but will be useful for maintainers who wish to include Cycle Time metrics and Repo Stats into repo readme.

![image](https://github.com/user-attachments/assets/3a8cb717-4caf-4d6a-86cf-bef0b9d48472)

Thank you for considering the PR