### PR TITLE
Add workflows for broken links

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/broken-links.yml
+++ b/.github/workflows/broken-links.yml
@@ -1,0 +1,28 @@
+name: Broken-Links
+
+on:
+    workflow_dispatch:
+    schedule:
+        - cron: "11 11 * * 0"   # once a week at 11:11 UTC on Sunday, avoid rush hours
+
+jobs:
+  linkChecker:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write # required for peter-evans/create-issue-from-file
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Link Checker
+        id: lychee
+        uses: lycheeverse/lychee-action@v2
+        with:
+          fail: false
+
+      - name: Create Issue From File
+        if: steps.lychee.outputs.exit_code != 0
+        uses: peter-evans/create-issue-from-file@v5
+        with:
+          title: Link Checker Report
+          content-filepath: ./lychee/out.md
+          labels: report, automated issue

--- a/.github/workflows/broken-links.yml
+++ b/.github/workflows/broken-links.yml
@@ -18,7 +18,7 @@ jobs:
         uses: lycheeverse/lychee-action@v2
         with:
           fail: false
-
+          output: ./lychee/out.md
       - name: Create Issue From File
         if: steps.lychee.outputs.exit_code != 0
         uses: peter-evans/create-issue-from-file@v5

--- a/.github/workflows/broken-links.yml
+++ b/.github/workflows/broken-links.yml
@@ -25,4 +25,4 @@ jobs:
         with:
           title: Link Checker Report
           content-filepath: ./lychee/out.md
-          labels: report, automated issue
+          labels: dead-link

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -1,0 +1,2 @@
+# remove badgen as it seems to block lychee user agent/github actions requests
+https://badgen.net/


### PR DESCRIPTION
Introduce a workflow to check for broken links weekly and create issues if any are found. Additionally, configure Dependabot to manage updates for GitHub Actions on a weekly basis for our new workflow.