### PR TITLE
readme: add dependents.info

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ includes Shields-related and non-Shields-related resources._
 - [NodeICO](https://nodei.co/) &ndash; Large-format status badges for Node.js
   projects &ndash; which were once very popular!
 - [PlayBadges](https://playbadges.pavi2410.me) &ndash; Show off your Play Store™ app's downloads and ratings in your repo
-- [badge.fury.io](https://badge.fury.io) - Service for version badges of packages like PyPI, npm, RubyGems, etc.
+- [badge.fury.io](https://badge.fury.io) &ndash; Service for version badges of packages like PyPI, npm, RubyGems, etc.
+- [dependents.info](https://dependents.info) &ndash; Showcase GitHub repository's network dependents with a badge and image.
 
 ### Badge tools
 


### PR DESCRIPTION
Added an [open source](https://github.com/gouravkhunger/dependents.info) tool I created that easily lets people showcase shields.io styled dependents count badges and optionally an auto-generated "Used by" image on their READMEs!