### PR TITLE
Add Absurd badges: a collection of humorous static badges 

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ includes Shields-related and non-Shields-related resources._
   four types of open-source project, as classified in Nadia Eghbal's
   _Working in Public_.
 - [Simple Badges](https://github.com/developStorm/simple-badges) &ndash; Catalog of Shields.io Badges with Simple Icons
+- [Absurd badges](https://github.com/sebmestrallet/absurd-badges) &ndash; Collection of absurd, humorous, static badges
 
 ### Dynamic data providers
 


### PR DESCRIPTION
This PR adds a reference to [Absurd badges](https://github.com/sebmestrallet/absurd-badges) (own work), a list of static badges based on common jokes & lore of software development.

Feel free to give your feedback on the list itself, as well as the way the repo is mentioned in `awesome-badges`.