### PR TITLE
Add Made by Human to Static badge collections

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ includes Shields-related and non-Shields-related resources._
   _Working in Public_.
 - [Simple Badges](https://github.com/developStorm/simple-badges) &ndash; Catalog of Shields.io Badges with Simple Icons
 - [Absurd badges](https://github.com/sebmestrallet/absurd-badges) &ndash; Collection of absurd, humorous, static badges
+- [Made by Human](https://madebyhuman.iamjarl.com) &ndash; Free SVG badges for transparency about human-AI collaboration: Made by Human, Co-created with AI, Crafted by Human, and Human in the Loop
 
 ### Dynamic data providers
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ includes Shields-related and non-Shields-related resources._
   _Working in Public_.
 - [Simple Badges](https://github.com/developStorm/simple-badges) &ndash; Catalog of Shields.io Badges with Simple Icons
 - [Absurd badges](https://github.com/sebmestrallet/absurd-badges) &ndash; Collection of absurd, humorous, static badges
-- [Made by Human](https://madebyhuman.iamjarl.com) &ndash; Free SVG badges for transparency about human-AI collaboration: Made by Human, Co-created with AI, Crafted by Human, and Human in the Loop
+- [Made by Human](https://madebyhuman.iamjarl.com) &ndash; SVG badges for transparency about human-AI collaboration: Made by Human, Co-created with AI, Crafted by Human, and Human in the Loop
 
 ### Dynamic data providers
 


### PR DESCRIPTION
Submitting [Made by Human](https://madebyhuman.iamjarl.com) — a free collection of SVG badges for transparent human-AI collaboration.

- **MIT licensed**, no attribution required
- **4 badge designs** (Made by Human, Co-created with AI, Crafted by Human, Human in the Loop) in white and black variants
- **Markdown/HTML/URL** embed codes available directly on the site
- **Live at** https://madebyhuman.iamjarl.com
- **Source:** https://github.com/JarlLyng/madebyhuman

Fits in the "Static badge collections" section alongside other curated badge catalogs like *Project Types* and *Absurd badges*. The entry is added at the end of that section to preserve existing ordering.

## Checklist
- [x] Relevance: project is a badge collection
- [x] Usefulness: free, copy-paste embed codes for developers and non-developers
- [x] Substance: actively maintained with 4 curated badge designs
- [x] Project is actively maintained (MIT, open source on GitHub)