### PR TITLE
Add shieldcn to dynamic badge services

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,10 @@ includes Shields-related and non-Shields-related resources._
 - [badge.fury.io](https://badge.fury.io) &ndash; Service for version badges of packages like PyPI, npm, RubyGems, etc.
 - [dependents.info](https://dependents.info) &ndash; Showcase GitHub repository's network dependents with a badge and image.
 - [BadgeSize.com](https://badgesize.com) &ndash; Display the size of any file accessible on GitHub, npm, a CDN service, or hosted elsewhere.
+- [shieldcn](https://shieldcn.dev) &ndash; Shields.io alternative that
+  renders badges as shadcn/ui Button components via Satori. Supports npm,
+  GitHub, Discord, Reddit, and more with dark/light mode, multiple variants,
+  and 40k+ icons.
 
 ### Badge tools
 - [Badgetizr](https://github.com/aiKrice/homebrew-badgetizr)  &ndash; Automatically adds customizable badges to your GitHub and GitLab pull/merge requests.


### PR DESCRIPTION
[shieldcn](https://shieldcn.dev) is a Shields.io alternative that renders badges as [shadcn/ui](https://ui.shadcn.com/) Button components via [Satori](https://github.com/vercel/satori). Built with Next.js, React, and Tailwind CSS.

**Features:**
- Data providers: npm, GitHub, Discord, Reddit, PyPI, NuGet, RubyGems, Codecov, and more
- 6 badge variants: default, secondary, outline, ghost, destructive, branded
- Dark/light mode, 10+ color themes
- 40,000+ icons from SimpleIcons, Lucide, and React Icons
- SVG and PNG output
- Shields.io-compatible JSON endpoint (`/shields.json`)

**GitHub:** https://github.com/jal-co/shieldcn